### PR TITLE
Test PG counters is accurate when using create_only_config_db_buffers…

### DIFF
--- a/tests/snmp/test_snmp_pg_counters.py
+++ b/tests/snmp/test_snmp_pg_counters.py
@@ -1,0 +1,66 @@
+import allure
+import pytest
+import json
+import os
+import time
+from tests.common.utilities import (wait, wait_until)
+from tests.common.helpers.assertions import pytest_assert
+
+TIMEOUT = 120
+
+pytestmark = [
+    pytest.mark.topology('any'),
+    pytest.mark.device_type('vs')
+]
+
+def load_new_config(duthost, path):
+    cfggen_cmd = "sudo sonic-cfggen -j {} --write-to-db".format(path)
+    reload_cmd = "sudo config reload {} -y".format(path)
+    duthost.shell(cfggen_cmd)
+    time.sleep(10)
+    duthost.shell(reload_cmd)
+    wait(TIMEOUT, "For config to reload \n")
+
+def test_snmp_pg_counters(duthosts, enum_rand_one_per_hwsku_frontend_hostname, localhost, creds_all_duts):
+    """
+    Test SNMP PG counters
+      - Set "create_only_config_db_buffers" to true in config db, to create only relevant pg counters
+      - Remove one of the buffer queues, Ethernet0|3-4 is chosen arbitrary
+      - Using snmpwalk compare number of PG counters on Ethernet0, assuming there will be 8 less after
+        removing the buffer. (Assuming unicast only, 4 pg counters for each lane in this case)
+    """
+
+    duthost = duthosts[enum_rand_one_per_hwsku_frontend_hostname]
+    hostip = duthost.host.options['inventory_manager'].get_host(
+        duthost.hostname).vars['ansible_host']
+    oid = '1.3.6.1.4.1.9.9.580.1.5.5.1.4.1'
+    dut_command = "docker exec snmp snmpwalk -v2c -c {} {} {}".format(
+        creds_all_duts[duthost.hostname]['snmp_rocommunity'], hostip, oid
+    )
+    
+    # Add create_only_config_db_buffers entry to device metadata to enable pg counters optimization
+    duthost.shell("sonic-cfggen -d --print-data > /etc/sonic/orig_config_db.json")
+    data = json.loads(duthost.shell("cat /etc/sonic/orig_config_db.json", verbose=False)['stdout'])
+    data['DEVICE_METADATA']["localhost"]["create_only_config_db_buffers"] = "true"
+    
+    path = "/tmp/modified_config_db.json"
+    duthost.copy(content=json.dumps(data, indent=4), dest=path)
+    load_new_config(duthost, path)
+
+    # Get number of pg counters of Ethernet0 prior to removing buffer queue
+    output_pre = duthost.shell(dut_command)
+    pg_counters_cnt_pre = len(output_pre["stdout_lines"])
+
+    # Remove buffer queue and reload
+    del data['BUFFER_QUEUE']["Ethernet0|3-4"]
+    duthost.copy(content=json.dumps(data, indent=4), dest=path)
+    load_new_config(duthost, path)
+
+    # Get number of pg counters of Ethernet0 after to removing buffer queue
+    output_post = duthost.shell(dut_command)
+    pg_counters_cnt_post = len(output_post["stdout_lines"])
+    
+    # Cleanup
+    load_new_config(duthost, "/etc/sonic/orig_config_db.json")
+
+    pytest_assert((pg_counters_cnt_pre - pg_counters_cnt_post) == 8, "Expected {} PG counters after modification, got {} instead".format((pg_counters_cnt_pre-8), pg_counters_cnt_post))


### PR DESCRIPTION
… optimization

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
This test is checking that PG counters inside snmp docker are accurate when using create_only_config_db_counters optimization.

Summary:
Fixes https://github.com/sonic-net/sonic-buildimage/issues/17448 and is related to the fix, available in https://github.com/sonic-net/sonic-snmpagent/pull/303

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)


### Back port request
- [ ] 201911
- [ ] 202012
- [x] 202205
- [x] 202305
- [x] 202311

### Approach
#### What is the motivation for this PR?
To enhance the bug fix mentioned above solving an issue with PG counters optimization.
#### How did you do it?
      - Set "create_only_config_db_buffers" to true in config db, to create only relevant PG counters.
      - Remove one of the buffer queues, Ethernet0|3-4 is arbitrary chosen.
      - Using snmpwalk compare number of PG counters on Ethernet0, assuming there will be 8 less after
        removing the buffer. (Assuming unicast only, 4 pg counters for each lane in this case).
#### How did you verify/test it?
Run the test multiple times on various setups.
#### Any platform specific information?
Test assumes unicast only
#### Supported testbed topology if it's a new test case?

### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
